### PR TITLE
Fix filename desync issue

### DIFF
--- a/lib/paperclip-strip-strange-characters.rb
+++ b/lib/paperclip-strip-strange-characters.rb
@@ -37,7 +37,10 @@ module ActiveRecord
       def strip_strange_characters_from_attachments
         if self.class.attachment_definitions
           self.class.attachment_definitions.each do |k,v|
-            if self.send(k).file?
+
+            # Only modify names of attachments that are being updated
+            # Otherwise, the record names & the paths in s3 can become desynchronized
+            if self.send(k).file? && self.send("#{k}_file_name_changed?")
               full_file_name = self.send("#{k}_file_name")
               extension = File.extname(full_file_name)
               file_name = full_file_name[0..full_file_name.size-extension.size-1]

--- a/lib/paperclip-strip-strange-characters.rb
+++ b/lib/paperclip-strip-strange-characters.rb
@@ -44,8 +44,13 @@ module ActiveRecord
               full_file_name = self.send("#{k}_file_name")
               extension = File.extname(full_file_name)
               file_name = full_file_name[0..full_file_name.size-extension.size-1]
+              new_file_name = file_name.strip_strange_characters
 
-              self.send("#{k}").instance_write(:file_name, "#{file_name.strip_strange_characters}.#{extension.strip_strange_characters}")
+              # Only modify the extension if there's one present
+              # Ex: Dont rename 'img-123' to 'img-123.d41d8cd98f00b204e9800998ecf8427e'
+              new_file_name += ".#{extension.strip_strange_characters}" if extension.present?
+
+              self.send("#{k}").instance_write(:file_name, new_file_name)
             end
           end
         end


### PR DESCRIPTION
Classes with multiple attachments should not have their file names updated, if only one of the attachments gets modified!
